### PR TITLE
replace sort-package-json with prettier-plugin-packagejson

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,7 +1,4 @@
 module.exports = {
-  // keep package json sorted
-  //'package.json': 'sort-package-json',
-
   // fomat all files recognized by prettier
   '*': 'prettier --ignore-unknown --write',
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treetracker-query-api",
-  "version": "1.4.1",
+  "version": "1.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "treetracker-query-api",
-      "version": "1.4.1",
+      "version": "1.5.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@sentry/node": "^5.1.0",
@@ -52,8 +52,8 @@
         "mock-knex": "^0.4.10",
         "node-cipher": "^5.0.1",
         "nodemon": "^2.0.14",
-        "prettier": "^2.4.1",
-        "sort-package-json": "^1.53.1",
+        "prettier": "^2.5.1",
+        "prettier-plugin-packagejson": "^2.2.15",
         "supertest": "^4.0.2",
         "ts-node": "^10.4.0",
         "typescript": "^4.4.4"
@@ -8342,6 +8342,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/prettier-plugin-packagejson": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.2.15.tgz",
+      "integrity": "sha512-r3WKxw0ALyD3gr3RlIFK3o7mUejCVkqwVKtUuPQaB3+aNiZYKxmad+GpZ6WFWTm6Zq2jX0wvSdlkGccQ2pEnCg==",
+      "dev": true,
+      "dependencies": {
+        "sort-package-json": "1.53.1"
+      },
+      "peerDependencies": {
+        "prettier": ">= 1.16.0"
       }
     },
     "node_modules/pretty-format": {
@@ -17136,6 +17148,15 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
       "dev": true
+    },
+    "prettier-plugin-packagejson": {
+      "version": "2.2.15",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.2.15.tgz",
+      "integrity": "sha512-r3WKxw0ALyD3gr3RlIFK3o7mUejCVkqwVKtUuPQaB3+aNiZYKxmad+GpZ6WFWTm6Zq2jX0wvSdlkGccQ2pEnCg==",
+      "dev": true,
+      "requires": {
+        "sort-package-json": "1.53.1"
+      }
     },
     "pretty-format": {
       "version": "27.4.6",

--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "mock-knex": "^0.4.10",
     "node-cipher": "^5.0.1",
     "nodemon": "^2.0.14",
-    "prettier": "^2.4.1",
-    "sort-package-json": "^1.53.1",
+    "prettier": "^2.5.1",
+    "prettier-plugin-packagejson": "^2.2.15",
     "supertest": "^4.0.2",
     "ts-node": "^10.4.0",
     "typescript": "^4.4.4"


### PR DESCRIPTION
There may be some unknown issues with running `sort-package-json`. This adds the same sorting rules to prettier instead. 

https://github.com/matzkoh/prettier-plugin-packagejson