### PR TITLE
fix: build error caused by package.json import in app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treetracker-query-api",
-  "version": "1.5.2",
+  "version": "1.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "treetracker-query-api",
-      "version": "1.5.2",
+      "version": "1.7.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@sentry/node": "^5.1.0",

--- a/server/app.ts
+++ b/server/app.ts
@@ -9,7 +9,8 @@ import treesRouter from './routers/treesRouter';
 import { errorHandler, handlerWrapper } from './routers/utils';
 import walletsRouter from './routers/walletsRouter';
 import HttpError from './utils/HttpError';
-import { version } from '../package.json';
+
+const version = process.env.npm_package_version;
 
 const app = express();
 


### PR DESCRIPTION
Importing `package.json` in `app.ts` caused the folder structure of the build output to mismatch the start script configuration.  Using [package vars ](https://docs.npmjs.com/cli/v6/using-npm/scripts#packagejson-vars) fixed this.