### PR TITLE
docker image uses build files

### DIFF
--- a/.github/workflows/treetracker-query-api-build-deploy-dev.yml
+++ b/.github/workflows/treetracker-query-api-build-deploy-dev.yml
@@ -35,6 +35,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - run: npm run build
+        working-directory: ${{ env.project-directory }}
+
+      - run: npm prune --production
+        working-directory: ${{ env.project-directory }}
+
       - name: get-npm-version
         id: package-version
         uses: martinbeentjes/npm-get-version-action@master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM node:16-alpine
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
+COPY node_modules ./node_modules/
 COPY package.json ./
 COPY package-lock.json ./
-RUN npm ci --silent
-COPY . ./
-# TODO replace to command for prod
-CMD [ "npm", "run", "dev" ]
+COPY dist ./dist/
+CMD [ "npm", "start" ]


### PR DESCRIPTION
resolves #61

I copied the configuration from [webmap-quer](https://github.com/QuaidBartolomei/webmap-query-service-consumer)

The production files in `dist/` are created with `npm run build`
Then dev depencies are no longer needed after the build step so they are removed with `npm prune --production`. 
