### PR TITLE
fix: getFeaturedTrees uses correct column

### DIFF
--- a/server/infra/database/BaseRepository.ts
+++ b/server/infra/database/BaseRepository.ts
@@ -5,9 +5,9 @@ import Filter from 'interfaces/Filter';
 import HttpError from 'utils/HttpError';
 import Session from './Session';
 
-type FilterOptions = {
+type FilterOptions<T> = {
   limit?: number;
-  orderBy?: { column: string; direction?: 'asc' | 'desc' };
+  orderBy?: { column: keyof T; direction?: 'asc' | 'desc' };
 };
 
 export default class BaseRepository<T> {
@@ -42,8 +42,8 @@ export default class BaseRepository<T> {
 
   async getByFilter<FilterType>(
     filter: Filter<FilterType>,
-    options?: FilterOptions,
-  ) {
+    options?: FilterOptions<T>,
+  ): Promise<T[]> {
     const whereBuilder = function (object: any, builder: Knex.QueryBuilder) {
       let result = builder;
       if (object.and) {
@@ -91,10 +91,10 @@ export default class BaseRepository<T> {
         options.orderBy.direction !== undefined
           ? options.orderBy.direction
           : 'asc';
-      promise = promise.orderBy(options.orderBy.column, direction);
+      promise = promise.orderBy(options.orderBy.column as string, direction);
     }
     const result = await promise;
-    return result;
+    return result as T[];
   }
 
   async countByFilter(filter: T) {

--- a/server/interfaces/Tree.ts
+++ b/server/interfaces/Tree.ts
@@ -2,4 +2,5 @@ export default interface Tree {
   id: number;
   lat: number;
   lon: number;
+  time_created: string;
 }

--- a/server/models/Tree.ts
+++ b/server/models/Tree.ts
@@ -27,12 +27,12 @@ function getByFilter(
  we just put the newest, verified tree
  */
 function getFeaturedTree(treeRepository: TreeRepository) {
-  return async function () {
+  return async () => {
     const trees = await treeRepository.getByFilter(
       {
         approved: true,
       },
-      { limit: 10, orderBy: { column: 'created_at', direction: 'desc' } },
+      { limit: 10, orderBy: { column: 'time_created', direction: 'desc' } },
     );
     // const trees: Array<Tree> = [];
     // // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
`getFeaturedTrees` was using the wrong column name for ordering the results. (It used `created_at` instead of the correct `time_created`). I improved the typing of `getByFilter` to require a correct column name based on its return type.
 