### PR TITLE
fix: url parse security warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treetracker-query-api",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "treetracker-query-api",
-      "version": "1.7.0",
+      "version": "1.9.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@sentry/node": "^5.1.0",
@@ -10366,9 +10366,9 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "peer": true,
       "dependencies": {
         "querystringify": "^2.1.1",
@@ -18731,9 +18731,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "peer": true,
       "requires": {
         "querystringify": "^2.1.1",


### PR DESCRIPTION
Automatic fix for production security warning
```
url-parse  <=1.5.8
Severity: critical
Authorization Bypass Through User-Controlled Key in url-parse - https://github.com/advisories/GHSA-jf5r-8hm2-f872
Authorization Bypass Through User-Controlled Key in url-parse - https://github.com/advisories/GHSA-hgjh-723h-mx2j
Authorization Bypass Through User-Controlled Key in url-parse - https://github.com/advisories/GHSA-8v38-pw62-9cw2
Authorization bypass in url-parse - https://github.com/advisories/GHSA-rqff-837h-mm52
```