### PR TITLE
feat: implement v2 for get /countries/leaderboard

### DIFF
--- a/__tests__/e2e/countries.spec.ts
+++ b/__tests__/e2e/countries.spec.ts
@@ -63,19 +63,16 @@ describe('', () => {
   it('countries/v2/leaderboard', async () => {
     const response = await seed
       .clear()
-      .then(
-        async () =>
-          seed
-            .seed()
-            .then(
-              async () => supertest(app).get('/countries/v2/leaderboard'),
-            ),
+      .then(async () =>
+        seed
+          .seed()
+          .then(async () => supertest(app).get('/countries/v2/leaderboard')),
       );
     expect(response.status).toBe(200);
     expect(response.body.countries[0]).toMatchObject({
-      id: expect.any(Number),
-      name: expect.any(String),
-      planted: expect.any(String),
+      id: 6632357,
+      name: 'United States',
+      planted: '2',
       centroid: expect.stringMatching(/coordinates/),
     });
     await seed.clear();

--- a/__tests__/e2e/countries.spec.ts
+++ b/__tests__/e2e/countries.spec.ts
@@ -1,5 +1,6 @@
 import supertest from 'supertest';
 import app from '../../server/app';
+import seed from '../seed';
 
 describe('', () => {
   it('countries/6632544', async () => {
@@ -58,4 +59,25 @@ describe('', () => {
     },
     1000 * 60,
   );
+
+  it('countries/v2/leaderboard', async () => {
+    const response = await seed
+      .clear()
+      .then(
+        async () =>
+          seed
+            .seed()
+            .then(
+              async () => supertest(app).get('/countries/v2/leaderboard'),
+            ),
+      );
+    expect(response.status).toBe(200);
+    expect(response.body.countries[0]).toMatchObject({
+      id: expect.any(Number),
+      name: expect.any(String),
+      planted: expect.any(String),
+      centroid: expect.stringMatching(/coordinates/),
+    });
+    await seed.clear();
+  });
 });

--- a/__tests__/seed.js
+++ b/__tests__/seed.js
@@ -27,6 +27,16 @@ const dataRawCaptureFeature = [
   },
   {
     id: uuid.v4(),
+    lat: '40.50414585511928',
+    lon: '-75.66275380279951',
+    location: '0101000020E6100000B514ED8E6AEA52C05D13F4D987C04440',
+    field_user_id: 5127,
+    field_username: 'test',
+    created_at: new Date().toUTCString(),
+    updated_at: new Date().toUTCString(),
+  },
+  {
+    id: uuid.v4(),
     lat: '57.57641356164619',
     lon: '-113.11416324692146',
     location: '0101000020E6100000B4FB5C734E475CC0E21E6AEBC7C94C40',

--- a/__tests__/seed.js
+++ b/__tests__/seed.js
@@ -1,0 +1,58 @@
+import { knex } from 'knex';
+import log from 'loglevel';
+const uuid = require('uuid');
+
+const connection = process.env.DATABASE_URL;
+
+!connection && log.warn('env var DATABASE_URL not set');
+
+const knexConfig = {
+  client: 'pg',
+  // debug: process.env.NODE_LOG_LEVEL === 'debug',
+  debug: true,
+  connection,
+  pool: { min: 0, max: 10 },
+};
+
+const dataRawCaptureFeature = [
+  {
+    id: uuid.v4(),
+    lat: '41.50414585511928',
+    lon: '-75.66275380279951',
+    location: '0101000020E6100000B514ED8E6AEA52C05D13F4D987C04440',
+    field_user_id: 5127,
+    field_username: 'test',
+    created_at: new Date().toUTCString(),
+    updated_at: new Date().toUTCString(),
+  },
+  {
+    id: uuid.v4(),
+    lat: '57.57641356164619',
+    lon: '-113.11416324692146',
+    location: '0101000020E6100000B4FB5C734E475CC0E21E6AEBC7C94C40',
+    field_user_id: 5127,
+    field_username: 'test',
+    created_at: new Date().toUTCString(),
+    updated_at: new Date().toUTCString(),
+  },
+];
+
+async function seed() {
+  knexConfig.searchPath = [process.env.DATABASE_SCHEMA, 'webmap'];
+  const serverCon = knex(knexConfig);
+  const response = await serverCon.transaction(async (trx) => {
+    return await trx.insert(dataRawCaptureFeature).into('raw_capture_feature');
+  });
+  serverCon.destroy();
+  return response;
+}
+
+async function clear() {
+  knexConfig.searchPath = [process.env.DATABASE_SCHEMA, 'webmap'];
+  const serverCon = knex(knexConfig);
+  const response = await serverCon('raw_capture_feature').del();
+  serverCon.destroy();
+  return response;
+}
+
+export default { clear, seed };

--- a/server/models/CountryV2.ts
+++ b/server/models/CountryV2.ts
@@ -17,4 +17,7 @@ export default {
   getCountries,
   getById: delegateRepository<CountryRepositoryV2, Country>('getById'),
   getByFilter: delegateRepository<CountryRepositoryV2, Country>('getByFilter'),
+  getLeaderBoard: delegateRepository<CountryRepositoryV2, Country>(
+    'getLeaderBoard',
+  ),
 };

--- a/server/routers/countriesRouter.ts
+++ b/server/routers/countriesRouter.ts
@@ -10,6 +10,19 @@ import CountryModelV2 from '../models/CountryV2';
 const router = express.Router();
 
 router.get(
+  '/v2/leaderboard',
+  handlerWrapper(async (req, res) => {
+    const repo = new CountryRepositoryV2(new Session());
+    const exe = CountryModelV2.getLeaderBoard(repo);
+    const result = await exe(req.params.id);
+    res.send({
+      countries: result,
+    });
+    res.end();
+  }),
+);
+
+router.get(
   '/v2/:id',
   handlerWrapper(async (req, res) => {
     Joi.assert(req.params.id, Joi.number().required());


### PR DESCRIPTION
Fixes issue #96 

Added leaderboard method to V2 API. Test automatically clears  `raw_capture_feature` table then populates it with known data, completes the test and clears the table at the end of testing.

![image](https://user-images.githubusercontent.com/61099792/159104425-9b882197-48f8-426f-a0b9-d5faad7d403e.png)
