### PR TITLE
Update raw-captures query to return distinct values

### DIFF
--- a/server/infra/database/RawCaptureRepository.ts
+++ b/server/infra/database/RawCaptureRepository.ts
@@ -147,7 +147,8 @@ export default class RawCaptureRepository extends BaseRepository<RawCapture> {
         `${this.tableName}.${sort?.order_by || 'created_at'}`,
         sort?.order || 'desc',
       )
-      .where((builder) => this.filterWhereBuilder(filter, builder));
+      .where((builder) => this.filterWhereBuilder(filter, builder))
+      .distinct();
 
     const { limit, offset } = options;
     if (limit) {


### PR DESCRIPTION
Issue:
The query api was returning duplicates of a capture after it was approved.

Fix:
Updated the query to only return distinct items from query.