### PR TITLE
Get /organizations/{id} change the order for associated planters #243

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treetracker-query-api",
-  "version": "1.53.2",
+  "version": "1.54.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "treetracker-query-api",
-      "version": "1.53.2",
+      "version": "1.54.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@sentry/node": "^5.1.0",
@@ -20,7 +20,7 @@
         "express-validator": "^6.4.0",
         "joi": "^17.5.0",
         "knex": "^0.95.14",
-        "loglevel": "^1.6.8",
+        "loglevel": "^1.8.0",
         "pg": "^8.7.1",
         "rascal": "^14.4.0",
         "response-time": "^2.3.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "express-validator": "^6.4.0",
     "joi": "^17.5.0",
     "knex": "^0.95.14",
-    "loglevel": "^1.6.8",
+    "loglevel": "^1.8.0",
     "pg": "^8.7.1",
     "rascal": "^14.4.0",
     "response-time": "^2.3.2",

--- a/server/models/Organization.ts
+++ b/server/models/Organization.ts
@@ -26,7 +26,7 @@ function getByFilter(
 function getOrganizationLinks(organization) {
   const links = {
     featured_trees: `/trees?organization_id=${organization.id}&limit=20&offset=0`,
-    associated_planters: `/planters?organization_id=${organization.id}&limit=20&offset=0`,
+    associated_planters: `/planters?organization_id=${organization.id}&limit=20&offset=0&order_by=about`,
     species: `/species?organization_id=${organization.id}&limit=20&offset=0`,
   };
   return links;


### PR DESCRIPTION
The endpoint: GET /organizations/{id} will return links which includes associated_planter currently, this link is: /planters?organization_id=${organization.id}&limit=20&offset=0 has been changed changed it to associated_planters:/organization_id=${organization.id}&limit=20&offset=0&order_by=about