### PR TITLE
feat: added links to GET by grower id

### DIFF
--- a/server/routers/growerAccountsRouter.ts
+++ b/server/routers/growerAccountsRouter.ts
@@ -82,6 +82,7 @@ router.get(
     const repo = new GrowerAccountRepository(new Session());
     const exe = GrowerAccountModel.getById(repo);
     const result = await exe(req.params.id);
+    result.links = GrowerAccountModel.getGrowerAccountLinks(result);
     res.send(result);
     res.end();
   }),


### PR DESCRIPTION
@dadiorchen I needed to add the featured trees, associated organizations and species to GET /v2/growers/[id]

before 
![image](https://user-images.githubusercontent.com/63400531/217351467-a81089e0-95cd-4a09-8387-171db224b818.png)

after

![image](https://user-images.githubusercontent.com/63400531/217351623-ccaa9e10-047d-461f-9a4d-480e011cfccc.png)
