### PR TITLE
Issue 285, Fix the growers.links issue for v2 

### DIFF
--- a/server/models/GrowerAccount.ts
+++ b/server/models/GrowerAccount.ts
@@ -51,7 +51,7 @@ function getByName(
 
 function getGrowerAccountLinks(planter) {
   const links = {
-    featured_trees: `/trees?planter_id=${planter.id}&limit=20&offset=0`,
+    featured_trees: `/v2/trees?planter_id=${planter.id}&limit=20&offset=0`,
     associated_organizations: `/organizations?planter_id=${planter.id}&limit=20&offset=0`,
     species: `/species?planter_id=${planter.id}&limit=20&offset=0`,
   };

--- a/server/routers/treesRouterV2.ts
+++ b/server/routers/treesRouterV2.ts
@@ -64,7 +64,6 @@ router.get(
       offset = 0,
       order_by,
       desc = true,
-      planter_id,
       organization_id,
       startDate,
       endDate,
@@ -83,14 +82,11 @@ router.get(
       },
     };
 
-    if (planter_id) {
-      // filter.planter_id = planter_id; This will have to be fixed later, currently the planter_id is not in the tree table
-      if (order_by) {
-        options.orderBy = {
-          column: order_by === 'created_at' ? 'time_created' : order_by,
-          direction: desc === true ? 'desc' : 'asc',
-        };
-      }
+    if (order_by) {
+      options.orderBy = {
+        column: order_by === 'created_at' ? 'time_created' : order_by,
+        direction: desc === true ? 'desc' : 'asc',
+      };
     } else if (organization_id) {
       filter.organization_id = organization_id;
     } else if (startDate && endDate) {

--- a/server/routers/treesRouterV2.ts
+++ b/server/routers/treesRouterV2.ts
@@ -77,17 +77,12 @@ router.get(
       limit,
       offset,
       orderBy: {
-        column: order_by || 'time_created',
+        column: order_by || 'created_at',
         direction: desc === true ? 'desc' : 'asc',
       },
     };
 
-    if (order_by) {
-      options.orderBy = {
-        column: order_by === 'created_at' ? 'time_created' : order_by,
-        direction: desc === true ? 'desc' : 'asc',
-      };
-    } else if (organization_id) {
+    if (organization_id) {
       filter.organization_id = organization_id;
     } else if (startDate && endDate) {
       filter.date_range = { startDate, endDate };

--- a/server/routers/treesRouterV2.ts
+++ b/server/routers/treesRouterV2.ts
@@ -9,7 +9,7 @@ import TreeModel from '../models/Tree';
 
 const router = express.Router();
 type Filter = Partial<{
-  planter_id: number;
+  planter_id: string;
   organization_id: number;
   date_range: { startDate: string; endDate: string };
   tag: string;
@@ -47,7 +47,7 @@ router.get(
     Joi.assert(
       req.query,
       Joi.object().keys({
-        planter_id: Joi.number().integer().min(0),
+        planter_id: Joi.string().uuid(),
         organization_id: Joi.number().integer().min(0),
         wallet_id: Joi.string().uuid(),
         tag: Joi.string(),
@@ -71,6 +71,7 @@ router.get(
       tag,
       wallet_id,
     } = req.query;
+
     const repo = new TreeRepositoryV2(new Session());
     const filter: Filter = {};
     const options: FilterOptions = {
@@ -83,7 +84,13 @@ router.get(
     };
 
     if (planter_id) {
-      filter.planter_id = planter_id;
+      // filter.planter_id = planter_id; This will have to be fixed later, currently the planter_id is not in the tree table
+      if (order_by) {
+        options.orderBy = {
+          column: order_by === 'created_at' ? 'time_created' : order_by,
+          direction: desc === true ? 'desc' : 'asc',
+        };
+      }
     } else if (organization_id) {
       filter.organization_id = organization_id;
     } else if (startDate && endDate) {


### PR DESCRIPTION
fixes #285 

![image](https://user-images.githubusercontent.com/63400531/222608094-9eb0dc85-8749-46bb-a01c-4f16de070808.png)
![image](https://user-images.githubusercontent.com/63400531/222608169-57685d53-2639-41d8-8f95-f8f056467a22.png)

the associated org links for growers are currently not used and the species will need to be done eventually. I couldnt find a way to link the planter id to the new uuid grower ids.  This should be enough for me to move on in the front end.