### PR TITLE
Make results of captures query distinct to avoid duplicates

### DIFF
--- a/server/infra/database/CaptureRepository.ts
+++ b/server/infra/database/CaptureRepository.ts
@@ -154,7 +154,8 @@ export default class CaptureRepository extends BaseRepository<Capture> {
         `,
         ),
       )
-      .where((builder) => this.filterWhereBuilder(filter, builder));
+      .where((builder) => this.filterWhereBuilder(filter, builder))
+      .distinct();
 
     promise = promise.orderBy(
       sort?.order_by || 'treetracker.capture.created_at',


### PR DESCRIPTION
Resolves #304 
