### PR TITLE
Revert "fix: shows only acitve trees for GET /tokens"

### DIFF
--- a/server/infra/database/TokensRepository.ts
+++ b/server/infra/database/TokensRepository.ts
@@ -89,13 +89,10 @@ export default class TokensRepository extends BaseRepository<Tokens> {
     const sql = `SELECT
         COUNT(*)
       from wallet.token as wlt_tkn
-      left join public.trees on
-      public.trees.uuid::text = wlt_tkn.capture_id::text
       left join wallet.wallet as wlt_wallet on
       wlt_wallet.id = wlt_tkn.wallet_id
       where wlt_wallet.id::text = '${filter.wallet}' or 
-      wlt_wallet.name = '${filter.wallet} and
-      public.trees.active = true'
+      wlt_wallet.name = '${filter.wallet}'
     `;
     const total = await this.session.getDB().raw(sql);
     return parseInt(total.rows[0].count.toString());;


### PR DESCRIPTION
Reverts Greenstand/treetracker-query-api#331