### PR TITLE
fix: incorrectly parsing organization_Id 

### DIFF
--- a/server/routers/utils.ts
+++ b/server/routers/utils.ts
@@ -65,7 +65,7 @@ const queryFormatter = (req) => {
     ...others,
   };
   if (req.query.organization_id) {
-    query.organization_id = req.query.organization_id;  
+    query.organization_id = JSON.parse(req.query.organization_id);
   }
 
   if (req.query.captures_amount_min) {


### PR DESCRIPTION
closes https://github.com/Greenstand/treetracker-query-api/issues/358