### PR TITLE
Update documentation for grower_account endpoint

### DIFF
--- a/docs/api/spec/query-api.yaml
+++ b/docs/api/spec/query-api.yaml
@@ -1537,11 +1537,9 @@ components:
         photo_url:
           type: string
           description: it would be great if we can set a wallet avatar and show it on the wallet page
-
     stakeholder:
       description: ''
       type: object
-
       properties:
         id:
           type: number
@@ -1557,7 +1555,6 @@ components:
           type: string
         phone:
           type: string
-
     capture:
       description: ''
       type: object
@@ -1572,29 +1569,83 @@ components:
           type: string
         image_url:
           type: string
-
     grower_account:
       description: ''
       type: object
       properties:
         id:
           type: number
+          format: uuid
+        wallet:
+          type: string
+        person_id:
+          type: number
+          format: uuid
+          nullable: true
+        organization_id:
+          type: number
+          format: uuid
+          nullable: true
         first_name:
           type: string
+        email:
+          type: string
+          format: email
+          nullable: true
+        phone:
+          type: string
+          nullable: true
+        image_url:
+          type: string
+        image_rotation:
+          type: number
+        status:
+          type: string
+        first_registration_at:
+          type: string
+          format: date-time
+        created_at:
+          type: string
+          format: date-time
+        updated_at:
+          type: string
+          format: date-time
         last_name:
           type: string
+          nullable: true
+        location:
+          type: string
+          description: 'The spatial location represented as geometry(Point,4326).'
+          nullable: true
+        lon:
+          type: number
+          nullable: true
+        lat:
+          type: number
+          nullable: true
+        bulk_pack_file_name:
+          type: string
+          nullable: true
+        gender:
+          type: string
+          nullable: true
+        about:
+          type: string
+          nullable: true
+        reference_id:
+          type: number
+          nullable: true
+        show_in_map:
+          type: boolean
         links:
           type: object
           properties:
             featured_trees:
               type: string
-              description: ''
             associated_organizations:
               type: string
-              description: ''
             species:
               type: string
-              description: ''
     field_data:
       description: ''
       type: object


### PR DESCRIPTION
# Description

[comment]: # 'Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.'

This branch updates the OpenAPI documentation for the `grower_account` endpoint according to v2 schema:

![grower_account_table](https://github.com/Greenstand/treetracker-query-api/assets/108169988/9ce33827-fb27-4c3c-a24e-bd3538b51fa9)

Additional Questions:
1. Shouldn't the endpoint be `v2/growers/{grower_account_id}`? It seems like there is a discrepancy between line 247 of yaml file and [line 81 of app.ts](https://github.com/Greenstand/treetracker-query-api/blob/fa194cb4a274ee688c2b26b58596147368d08b9e/server/app.ts#L81) (`app.use('/v2/growers', growerAccountsRouter)`)

<br />

## Type of change

[comment]: # 'Please delete options that are not relevant.'

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
