### PR TITLE
Yaml Documentation Update (tree and capture response objects)

### DIFF
--- a/docs/api/spec/query-api.yaml
+++ b/docs/api/spec/query-api.yaml
@@ -1302,43 +1302,46 @@ components:
           maxItems: 2
           description: 2 points defining the bounding box
     tree:
-      description: a single tree object
+      description: A single tree object
       type: object
       x-examples: {}
       title: ''
       properties:
         id:
           type: number
-        photo_url:
-          type: string
-        verified:
-          type: boolean
-        token_id:
-          type: string
-        created_at:
+        latest_capture_id:
+          type: number
+        image_url:
           type: string
         lat:
           type: number
         lon:
           type: number
-        species_id:
-          type: number
-        planter_id:
-          type: number
+        estimated_geometric_location:
+          type: string
         gps_accuracy:
           type: number
-        capture_id:
-          type: string
-          description: "In the public.trees table, it's the uuid column"
-        capture_approval_tag:
-          type: string
-        domain_specific_data:
-          type: object
         morphology:
           type: string
-        rejection_reason:
-          type: string
         age:
+          type: number
+        created_at:
+          type: string
+        updated_at:
+          type: string
+        estimated_geographic_location:
+          type: string
+        status:
+          type: string
+        attributes:
+          type: string
+        species_id:
+          type: number
+        species_name:
+          type: string
+        species_description:
+          type: string
+        country_name:
           type: string
     country:
       description: ''
@@ -1556,7 +1559,7 @@ components:
         phone:
           type: string
     capture:
-      description: ''
+      description: A tree photo capture and its associated data package, representing a tree at a given moment in time
       type: object
       properties:
         id:
@@ -1568,6 +1571,18 @@ components:
         time_created:
           type: string
         image_url:
+          type: string
+        grower_id:
+          type: number
+        growing_organization_id:
+          type: number
+        token_id:
+          type: number
+        approved:
+          type: boolean
+        wallet_id:
+          type: number
+        wallet_name:
           type: string
     grower_account:
       description: ''


### PR DESCRIPTION
# Description

This branch updates the OpenAPI documentation for the `tree` and `capture` response objects according to the [v2 domain model](https://app.gitbook.com/o/-MXNadx4i6aOZ12XcStA/s/-MWfUniHAtkV1kYf898m/v2-web-map) and project discussion on 7/04/24.

## Details

The `tree` and `capture` database tables specified in the v2 domain model do not include a number of fields that the web map client relies on:

- `grower_id`
- `growing_organization_id`
- `country_name`
- `token_id`
- `approved`
- `species_name`
- `species_desc`
- `wallet_name`
- `wallet_id`

Since the denormalized response objects coming from the query api have not been specified, a discussion was required to decide where these missing fields would likely come from. A number of decisions were made during the 7/04/24 meeting, but changes will be ongoing as v2 development progresses.

As of now:
- Because the Greenstand product changes (v2) will allow a single tree to be cared for and sponsored by different growers and organizations at different stages of the tree's life, data specific to growers, wallets, and organizations will be part of the `capture` entity only. `tree`s are more dynamic entities that may change over time. 
- Species data:
  - Because species information can be updated during the capture verification process (if a tree were previously misidentified, for example), future discussions will need to address how `tree.species_id` in the tree database table will stay updated. 
  - `species_desc` and `species_name` fields may end up coming from a client-side request to the herbarium api in the future, but will be included on the `tree` response object, for now. 

@dadiorchen 's Slack notes from 7/04/24 meeting:

<img width="381" alt="dadior_slack_7_04" src="https://github.com/Greenstand/treetracker-query-api/assets/108169988/f6e1aad6-981b-478b-82ad-d4f76b644e61">