### PR TITLE
Add PostgREST service at /query-postgrest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# [1.75.0](https://github.com/Greenstand/treetracker-query-api/compare/v1.74.1...v1.75.0) (2025-02-24)
+
+### Bug Fixes
+
+- add limit to tree query by geometry ([70926eb](https://github.com/Greenstand/treetracker-query-api/commit/70926eb7644d1e9ff5687afdbebe16031557eb55))
+- change geometry input format to geojson array ([fd50334](https://github.com/Greenstand/treetracker-query-api/commit/fd5033457a09a6ce43e3a6c5f9078352b31b29a2))
+
+### Features
+
+- add filter by geom for trees route ([97f583e](https://github.com/Greenstand/treetracker-query-api/commit/97f583ef0143e8284f748848fecb68b56f197125))
+
 ## [1.74.1](https://github.com/Greenstand/treetracker-query-api/compare/v1.74.0...v1.74.1) (2025-02-03)
 
 ### Bug Fixes

--- a/__tests__/e2e/trees.spec.ts
+++ b/__tests__/e2e/trees.spec.ts
@@ -137,10 +137,30 @@ describe('trees', () => {
   );
 
   it(
-    'trees?lat=39.0619&lon=-122.6064&lat=38.1519&lon=-123.3139&lat=37.8879&lon=-121.1001',
+    'trees/?geoJsonStr=encodedgeoJson',
     async () => {
+      const geoJsonArr = [
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [-122.6064, 39.0619] },
+          properties: {},
+        },
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [-123.3139, 38.1519] },
+          properties: {},
+        },
+        {
+          type: 'Feature',
+          geometry: { type: 'Point', coordinates: [-121.1001, 37.8879] },
+          properties: {},
+        },
+      ];
+
+      const encodedgeoJson = encodeURIComponent(JSON.stringify(geoJsonArr));
+
       const response = await supertest(app).get(
-        '/trees?lat=39.0619&lon=-122.6064&lat=38.1519&lon=-123.3139&lat=37.8879&lon=-121.1001',
+        `/trees?geoJsonStr=${encodedgeoJson}`,
       );
       expect(response.status).toBe(200);
       expect(response.body.trees.length).toBe(145);

--- a/__tests__/e2e/trees.spec.ts
+++ b/__tests__/e2e/trees.spec.ts
@@ -1,3 +1,4 @@
+import exp from 'constants';
 import supertest from 'supertest';
 import app from '../../server/app';
 
@@ -164,6 +165,7 @@ describe('trees', () => {
       );
       expect(response.status).toBe(200);
       expect(response.body.trees.length).toBe(145);
+      expect(response.body.total).toBe(145);
     },
     1000 * 30,
   );

--- a/__tests__/e2e/trees.spec.ts
+++ b/__tests__/e2e/trees.spec.ts
@@ -135,4 +135,16 @@ describe('trees', () => {
     },
     1000 * 30,
   );
+
+  it(
+    'trees?lat=39.0619&lon=-122.6064&lat=38.1519&lon=-123.3139&lat=37.8879&lon=-121.1001',
+    async () => {
+      const response = await supertest(app).get(
+        '/trees?lat=39.0619&lon=-122.6064&lat=38.1519&lon=-123.3139&lat=37.8879&lon=-121.1001',
+      );
+      expect(response.status).toBe(200);
+      expect(response.body.trees.length).toBe(145);
+    },
+    1000 * 30,
+  );
 });

--- a/deployment/base/deployment.yaml
+++ b/deployment/base/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1
+﻿apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: treetracker-query-api
@@ -15,18 +15,10 @@ spec:
       labels:
         app: treetracker-query-api
     spec:
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: doks.digitalocean.com/node-pool
-                    operator: In
-                    values:
-                      - microservices-node-pool
       containers:
         - name: treetracker-query-api
-          image: greenstand/treetracker-query-api:TAG
+          image: greenstand/treetracker-query-api:v1.2.3
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
           env:

--- a/deployment/base/kustomization.yaml
+++ b/deployment/base/kustomization.yaml
@@ -1,5 +1,12 @@
+﻿apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
+  - namespace.yaml
   - deployment.yaml
-  - mapping.yaml
   - service.yaml
   - database-connection-sealed-secret.yaml
+  - postgrest-config.yaml
+  - postgrest-deployment.yaml
+  - postgrest-service.yaml
+  - postgrest-ingress.yaml
+

--- a/deployment/base/postgrest-config.yaml
+++ b/deployment/base/postgrest-config.yaml
@@ -1,0 +1,11 @@
+﻿apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgrest-config
+  namespace: webmap
+data:
+  postgrest.conf: |
+    db-uri = "$(PGRST_DB_URI)"
+    db-schema = "public"
+    db-anon-role = "readonly_user"
+    server-port = 3000

--- a/deployment/base/postgrest-deployment.yaml
+++ b/deployment/base/postgrest-deployment.yaml
@@ -1,0 +1,32 @@
+﻿apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgrest
+  namespace: webmap
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgrest
+  template:
+    metadata:
+      labels:
+        app: postgrest
+    spec:
+      containers:
+      - name: postgrest
+        image: postgrest/postgrest:v12.0.2
+        ports:
+        - containerPort: 3000
+        env:
+        - name: PGRST_DB_URI
+          valueFrom:
+            secretKeyRef:
+              name: query-api-database-connection
+              key: db
+        - name: PGRST_DB_SCHEMA
+          value: "public"
+        - name: PGRST_DB_ANON_ROLE
+          value: "readonly_user"
+        - name: PGRST_SERVER_PORT
+          value: "3000"

--- a/deployment/base/postgrest-ingress.yaml
+++ b/deployment/base/postgrest-ingress.yaml
@@ -1,0 +1,18 @@
+﻿apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: postgrest-ingress
+  namespace: webmap
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /query-postgrest(/|$)(.*)
+        pathType: Prefix
+        backend:
+          service:
+            name: postgrest-service
+            port:
+              number: 3000

--- a/deployment/base/postgrest-service.yaml
+++ b/deployment/base/postgrest-service.yaml
@@ -1,0 +1,12 @@
+﻿apiVersion: v1
+kind: Service
+metadata:
+  name: postgrest-service
+  namespace: webmap
+spec:
+  selector:
+    app: postgrest
+  ports:
+  - port: 3000
+    targetPort: 3000
+  type: ClusterIP

--- a/deployment/base/service.yaml
+++ b/deployment/base/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: treetracker-query-api
+  namespace: webmap
 spec:
   selector:
     app: treetracker-query-api
@@ -9,4 +10,4 @@ spec:
     - name: http
       protocol: TCP
       port: 80
-      targetPort: 3006
+      targetPort: 3006  # change if container doesn't use 3006

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treetracker-query-api",
-  "version": "1.73.0",
+  "version": "1.75.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "treetracker-query-api",
-      "version": "1.73.0",
+      "version": "1.75.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@sentry/node": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treetracker-query-api",
-  "version": "1.74.1",
+  "version": "1.75.0",
   "private": false,
   "keywords": [
     "ecology"

--- a/server/infra/database/TreeRepository.ts
+++ b/server/infra/database/TreeRepository.ts
@@ -4,6 +4,12 @@ import HttpError from 'utils/HttpError';
 import BaseRepository from './BaseRepository';
 import Session from './Session';
 
+type GeoJson = Partial<{
+  geometry: {
+    coordinates: number[];
+  };
+}>;
+
 export default class TreeRepository extends BaseRepository<Tree> {
   constructor(session: Session) {
     super('trees', session);
@@ -305,13 +311,14 @@ export default class TreeRepository extends BaseRepository<Tree> {
     return object.rows;
   }
 
-  async getByGeometry(
-    geometry: { lat: Array<number>; lon: Array<number> },
-    totalCount = false,
-  ) {
-    const pointArray = geometry.lon.map((item, i) => `ST_MakePoint(${item}, ${geometry.lat[i]})`);
-    pointArray.push(`ST_MakePoint(${geometry.lon[0]}, ${geometry.lat[0]})`);
-
+  async getByGeometry(geoJsonArr: GeoJson[], totalCount = false) {
+    const pointArray = geoJsonArr.map(
+      (item) =>
+        `ST_MakePoint(${item.geometry?.coordinates[0]}, ${item.geometry?.coordinates[1]})`,
+    );
+    pointArray.push(
+      `ST_MakePoint(${geoJsonArr[0].geometry?.coordinates[0]}, ${geoJsonArr[0].geometry?.coordinates[1]})`,
+    );
     if (totalCount) {
       const totalSql = `
         SELECT

--- a/server/infra/database/TreeRepository.ts
+++ b/server/infra/database/TreeRepository.ts
@@ -311,7 +311,12 @@ export default class TreeRepository extends BaseRepository<Tree> {
     return object.rows;
   }
 
-  async getByGeometry(geoJsonArr: GeoJson[], totalCount = false) {
+  async getByGeometry(
+    geoJsonArr: GeoJson[],
+    options: FilterOptions,
+    totalCount = false,
+  ) {
+    const { limit } = options;
     const pointArray = geoJsonArr.map(
       (item) =>
         `ST_MakePoint(${item.geometry?.coordinates[0]}, ${item.geometry?.coordinates[1]})`,
@@ -343,6 +348,7 @@ export default class TreeRepository extends BaseRepository<Tree> {
       ST_SETSRID(ST_CONVEXHULL(ST_MAKELINE(ARRAY[${pointArray.toString()}])), 4326),
       ST_SETSRID(ST_POINT(t.lon, t.lat), 4326)
       )
+      LIMIT ${limit}
       `;
 
     const object = await this.session.getDB().raw(sql);

--- a/server/models/Tree.ts
+++ b/server/models/Tree.ts
@@ -4,12 +4,17 @@ import Tree from 'interfaces/Tree';
 import { delegateRepository } from '../infra/database/delegateRepository';
 import TreeRepository from '../infra/database/TreeRepository';
 
+type GeoJson = Partial<{
+  geometry: {
+    coordinates: number[];
+  };
+}>;
 type Filter = Partial<{
   organization_id: number;
   date_range: { startDate: string; endDate: string };
   tag: string;
   wallet_id: string;
-  geometry: { lat: Array<number>; lon: Array<number> };
+  geoJsonArr: GeoJson[];
 }>;
 
 function getByFilter(
@@ -42,9 +47,9 @@ function getByFilter(
       const trees = await treeRepository.getByWallet(filter.wallet_id, options);
       return trees;
     }
-    if (filter.geometry) {
+    if (filter.geoJsonArr) {
       log.warn('using geometry filter...');
-      const trees = await treeRepository.getByGeometry(filter.geometry);
+      const trees = await treeRepository.getByGeometry(filter.geoJsonArr);
       return trees;
     }
 
@@ -90,9 +95,9 @@ function countByFilter(
       return total;
     }
 
-    if (filter.geometry) {
+    if (filter.geoJsonArr) {
       log.warn('using geometry filter...');
-      const total = await treeRepository.getByGeometry(filter.geometry, true);
+      const total = await treeRepository.getByGeometry(filter.geoJsonArr, true);
       return total;
     }
     const total = await treeRepository.countByFilter(filter);

--- a/server/models/Tree.ts
+++ b/server/models/Tree.ts
@@ -9,6 +9,7 @@ type Filter = Partial<{
   date_range: { startDate: string; endDate: string };
   tag: string;
   wallet_id: string;
+  geometry: { lat: Array<number>; lon: Array<number> };
 }>;
 
 function getByFilter(
@@ -39,6 +40,11 @@ function getByFilter(
     if (filter.wallet_id) {
       log.warn('using wallet filter...');
       const trees = await treeRepository.getByWallet(filter.wallet_id, options);
+      return trees;
+    }
+    if (filter.geometry) {
+      log.warn('using geometry filter...');
+      const trees = await treeRepository.getByGeometry(filter.geometry);
       return trees;
     }
 
@@ -84,6 +90,11 @@ function countByFilter(
       return total;
     }
 
+    if (filter.geometry) {
+      log.warn('using geometry filter...');
+      const total = await treeRepository.getByGeometry(filter.geometry, true);
+      return total;
+    }
     const total = await treeRepository.countByFilter(filter);
     return total;
   };

--- a/server/models/Tree.ts
+++ b/server/models/Tree.ts
@@ -49,7 +49,10 @@ function getByFilter(
     }
     if (filter.geoJsonArr) {
       log.warn('using geometry filter...');
-      const trees = await treeRepository.getByGeometry(filter.geoJsonArr);
+      const trees = await treeRepository.getByGeometry(filter.geoJsonArr, {
+        ...options,
+        limit: 500,
+      });
       return trees;
     }
 
@@ -97,7 +100,11 @@ function countByFilter(
 
     if (filter.geoJsonArr) {
       log.warn('using geometry filter...');
-      const total = await treeRepository.getByGeometry(filter.geoJsonArr, true);
+      const total = await treeRepository.getByGeometry(
+        filter.geoJsonArr,
+        options,
+        true,
+      );
       return total;
     }
     const total = await treeRepository.countByFilter(filter);

--- a/server/routers/treesRouter.ts
+++ b/server/routers/treesRouter.ts
@@ -15,6 +15,7 @@ type Filter = Partial<{
   tag: string;
   wallet_id: string;
   active: true;
+  geometry: { lat: Array<number>; lon: Array<number> };
 }>;
 
 router.get(
@@ -70,6 +71,8 @@ router.get(
         offset: Joi.number().integer().min(0),
         startDate: Joi.string().regex(/^\d{4}-\d{2}-\d{2}$/),
         endDate: Joi.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+        lat: Joi.array().items(Joi.number()),
+        lon: Joi.array().items(Joi.number()),
       }),
     );
     const {
@@ -83,6 +86,8 @@ router.get(
       endDate,
       tag,
       wallet_id,
+      lat,
+      lon,
     } = req.query;
     const repo = new TreeRepository(new Session());
     const filter: Filter = { active: true };
@@ -105,6 +110,8 @@ router.get(
       filter.tag = tag;
     } else if (wallet_id) {
       filter.wallet_id = wallet_id;
+    } else if (lat && lon) {
+      filter.geometry = { lat, lon };
     }
 
     const result = await TreeModel.getByFilter(repo)(filter, options);


### PR DESCRIPTION
This PR adds a PostgREST service to the treetracker-query-api deployment to enable a read-only API endpoint for accessing tree data.

Changes:
* New Kubernetes service and deployment configs for PostgREST (postgrest-service.yaml, postgrest-deployment.yaml, etc.)
* Ingress configuration to expose the service at /query-postgrest.
* Uses the same readonly DB credentials defined in the sealed secret
* Integrated with existing kustomization and base deployment files

Testing:
Deployed on local dev cluster at http://localhost:8080/query-postgrest/trees
Confirmed /health route returns version
Confirmed /trees endpoint returns expected tree list using the PostgREST route

Goal:
Deploy to https://[env]-k8s.treetracker.org/query-postgrest for lightweight, readonly access to tree data via a standardized REST interface.