### PR TITLE
feat(deployment): add PostgREST deployment for query API

### DIFF
--- a/deployment/base/kustomization.yaml
+++ b/deployment/base/kustomization.yaml
@@ -3,3 +3,6 @@ resources:
   - mapping.yaml
   - service.yaml
   - database-connection-sealed-secret.yaml
+  - postgrest-deployment.yaml
+  - postgrest-service.yaml
+  - postgrest-mapping.yaml

--- a/deployment/base/postgrest-deployment.yaml
+++ b/deployment/base/postgrest-deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: treetracker-postgrest
+  labels:
+    app: treetracker-postgrest
+  namespace: webmap
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: treetracker-postgrest
+  template:
+    metadata:
+      labels:
+        app: treetracker-postgrest
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: doks.digitalocean.com/node-pool
+                    operator: In
+                    values:
+                      - microservices-node-pool
+      containers:
+        - name: postgrest
+          image: postgrest/postgrest:v12.0.2
+          ports:
+            - containerPort: 3000
+          env:
+            - name: PGRST_DB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: query-api-database-connection
+                  key: db
+            - name: PGRST_DB_SCHEMAS
+              value: "public"
+            - name: PGRST_DB_ANON_ROLE
+              value: "s_query"
+            - name: PGRST_OPENAPI_SERVER_PROXY_URI
+              value: "https://dev-k8s.treetracker.org/query-postgrest"
+            - name: PGRST_DB_EXTRA_SEARCH_PATH
+              value: "public"
+            - name: PGRST_SERVER_PORT
+              value: "3000"
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+

--- a/deployment/base/postgrest-mapping.yaml
+++ b/deployment/base/postgrest-mapping.yaml
@@ -1,0 +1,11 @@
+apiVersion: getambassador.io/v2
+kind: Mapping
+metadata:
+  name: treetracker-postgrest
+  namespace: webmap
+spec:
+  prefix: /query-postgrest/
+  service: treetracker-postgrest
+  rewrite: /
+  timeout_ms: 0
+

--- a/deployment/base/postgrest-service.yaml
+++ b/deployment/base/postgrest-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: treetracker-postgrest
+spec:
+  selector:
+    app: treetracker-postgrest
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 3000
+


### PR DESCRIPTION
- Add PostgREST deployment, service, and mapping configurations
- Configure route /query-postgrest for PostgREST API
- Use existing query-api-database-connection secret
- Set PGRST_DB_ANON_ROLE to s_query (may need adjustment after deployment)

Resolves #386