### PR TITLE
fix: resolve CORS misconfiguration blocking test-admin /verify endpoint

### DIFF
--- a/deployment/overlays/test/kustomization.yaml
+++ b/deployment/overlays/test/kustomization.yaml
@@ -2,3 +2,4 @@ bases:
   - ../../base
 patchesStrategicMerge:
   - database-connection-sealed-secret.yaml
+  - mapping.yaml

--- a/deployment/overlays/test/mapping.yaml
+++ b/deployment/overlays/test/mapping.yaml
@@ -5,7 +5,6 @@ metadata:
   name: treetracker-query-api
 spec:
   cors:
-    cors:
     origins:
       - '*'
     headers:

--- a/deployment/overlays/test/mapping.yaml
+++ b/deployment/overlays/test/mapping.yaml
@@ -3,6 +3,7 @@ apiVersion: getambassador.io/v2
 kind: Mapping
 metadata:
   name: treetracker-query-api
+  namespace: webmap
 spec:
   cors:
     origins:


### PR DESCRIPTION
Fixes #1191

## Root Cause
`mapping.yaml` in `overlays/test/` was not referenced in `kustomization.yaml`, 
meaning the Ambassador CORS configuration was never applied to the test environment. 
Additionally, the mapping had an incorrect double-nested `cors.cors` schema which 
would have silently failed even if applied.

## Changes
- `kustomization.yaml`: added `mapping.yaml` to `patchesStrategicMerge`
- `mapping.yaml`: corrected Ambassador v2 CORS schema (removed double `cors` nesting)

## Verification
- `dev-admin.treetracker.org/verify` works correctly (dev mapping is applied)
- `test-admin.treetracker.org/verify` returns CORS error — confirmed via browser 
  dev tools: `No 'Access-Control-Allow-Origin' header present`
- The fix mirrors the pattern that works in dev