### PR TITLE
feat(planter): exclude planters with show_in_map=false from all queries

### DIFF
--- a/server/infra/database/PlanterRepository.ts
+++ b/server/infra/database/PlanterRepository.ts
@@ -28,6 +28,7 @@ export default class PlanterRepository extends BaseRepository<Planter> {
       `),
       )
       .where('planter.id', id)
+      .andWhere('planter.show_in_map', true)
       .first();
 
     if (!object) {
@@ -186,8 +187,9 @@ export default class PlanterRepository extends BaseRepository<Planter> {
       LEFT JOIN webmap.planter_location l ON l.id = planter.id
       join (
       SELECT json_array_elements(data -> 'planters') AS planter_id FROM webmap.config WHERE name = 'featured-planter'
-      ) AS t ON 
-      t.planter_id::text::integer = planter.id;
+      ) AS t ON
+      t.planter_id::text::integer = planter.id
+      WHERE planter.show_in_map = true
     `;
     const object = await this.session.getDB().raw(sql);
 

--- a/server/infra/database/PlanterRepository.ts
+++ b/server/infra/database/PlanterRepository.ts
@@ -56,6 +56,7 @@ export default class PlanterRepository extends BaseRepository<Planter> {
            AND planter_registrations.created_at = (Select Min(created_at) from planter_registrations as planter_reg where planter_reg.planter_id=planter.id)
       LEFT JOIN webmap.planter_location l ON l.id = planter.id
       WHERE planter.organization_id in (select entity_id from getEntityRelationshipChildren(${organization_id}))
+      AND planter.show_in_map = true
       ${
         options.orderBy
           ? `order by ${options.orderBy.column} ${options.orderBy.direction}`
@@ -88,6 +89,7 @@ export default class PlanterRepository extends BaseRepository<Planter> {
         COUNT(*)
       FROM planter
       WHERE planter.organization_id in (select entity_id from getEntityRelationshipChildren(${organization_id}))
+      AND planter.show_in_map = true
     `;
     const total = await this.session.getDB().raw(totalSql);
     return parseInt(total.rows[0].count.toString());
@@ -105,6 +107,7 @@ export default class PlanterRepository extends BaseRepository<Planter> {
            ON planter.id = planter_registrations.planter_id
            AND planter_registrations.created_at = (Select Min(created_at) from planter_registrations as planter_reg where planter_reg.planter_id=planter.id)
       LEFT JOIN webmap.planter_location l ON l.id = planter.id
+      WHERE planter.show_in_map = true
       ${
         options.orderBy
           ? `order by ${options.orderBy.column} ${options.orderBy.direction}`
@@ -115,6 +118,16 @@ export default class PlanterRepository extends BaseRepository<Planter> {
     `;
     const object = await this.session.getDB().raw(sql);
     return object.rows;
+  }
+
+  async countByFilter(filter: Filter) {
+    const totalSql = `
+      SELECT COUNT(*)
+      FROM planter
+      WHERE planter.show_in_map = true
+    `;
+    const total = await this.session.getDB().raw(totalSql);
+    return parseInt(total.rows[0].count.toString());
   }
 
   async getByName(keyword: string, options: FilterOptions) {
@@ -128,7 +141,8 @@ export default class PlanterRepository extends BaseRepository<Planter> {
       LEFT JOIN planter_registrations
            ON planter.id = planter_registrations.planter_id
            AND planter_registrations.created_at = (Select Min(created_at) from planter_registrations as planter_reg where planter_reg.planter_id=planter.id)      LEFT JOIN webmap.planter_location l ON l.id = planter.id
-      WHERE planter.first_name LIKE '${keyword}%' OR planter.last_name LIKE '${keyword}%'
+      WHERE (planter.first_name LIKE '${keyword}%' OR planter.last_name LIKE '${keyword}%')
+      AND planter.show_in_map = true
       ORDER BY planter.first_name, planter.last_name
       LIMIT ${limit}
       OFFSET ${offset}
@@ -155,7 +169,8 @@ export default class PlanterRepository extends BaseRepository<Planter> {
       SELECT
       COUNT(*)
       FROM planter
-      WHERE planter.first_name LIKE '${keyword}%' OR planter.last_name LIKE '${keyword}%'
+      WHERE (planter.first_name LIKE '${keyword}%' OR planter.last_name LIKE '${keyword}%')
+      AND planter.show_in_map = true
     `;
     const total = await this.session.getDB().raw(totalSql);
     return parseInt(total.rows[0].count.toString());

--- a/server/infra/database/TreeRepository.ts
+++ b/server/infra/database/TreeRepository.ts
@@ -118,7 +118,9 @@ export default class TreeRepository extends BaseRepository<Tree> {
             planter.organization_id in ( SELECT entity_id from getEntityRelationshipChildren(${organization_id}))
           OR
             trees.planting_organization_id = ${organization_id}
-          ) and trees.active = true
+          )
+          AND trees.active = true
+          AND planter.show_in_map = true
       `;
       const total = await this.session.getDB().raw(totalSql);
       return parseInt(total.rows[0].count.toString());
@@ -136,8 +138,8 @@ export default class TreeRepository extends BaseRepository<Tree> {
       FROM trees
       LEFT JOIN planter ON trees.planter_id = planter.id
       LEFT JOIN entity ON entity.id = planter.organization_id
-      LEFT JOIN tree_species 
-        on trees.species_id = tree_species.id 
+      LEFT JOIN tree_species
+        on trees.species_id = tree_species.id
       LEFT JOIN region
         on ST_WITHIN(trees.estimated_geometric_location, region.geom)
         and region.type_id in (select id from region_type where type = 'country')
@@ -147,7 +149,8 @@ export default class TreeRepository extends BaseRepository<Tree> {
         OR
           trees.planting_organization_id = ${organization_id}
         )
-        and trees.active = true
+        AND trees.active = true
+        AND planter.show_in_map = true
       LIMIT ${limit}
       OFFSET ${offset}
     `;
@@ -260,18 +263,21 @@ export default class TreeRepository extends BaseRepository<Tree> {
     const sql = `
       SELECT trees.* ,tree_species.name as species_name,
       country.id as country_id, country.name as country_name
-      FROM trees 
+      FROM trees
       join (
       --- convert json array to row
       SELECT json_array_elements(data -> 'trees') AS tree_id FROM webmap.config WHERE name = 'featured-tree'
-      ) AS t ON 
+      ) AS t ON
       --- cast json type t.tree_id to integer
       t.tree_id::text::integer = trees.id
-      LEFT JOIN tree_species 
+      JOIN planter
+      ON trees.planter_id = planter.id
+      LEFT JOIN tree_species
       ON trees.species_id = tree_species.id
       LEFT JOIN region as country ON ST_WITHIN(trees.estimated_geometric_location, country.geom)
             and country.type_id in
               (SELECT id FROM region_type WHERE type = 'country')
+      WHERE planter.show_in_map = true
     `;
     const object = await this.session.getDB().raw(sql);
     return object.rows;

--- a/server/routers/organizationsRouter.ts
+++ b/server/routers/organizationsRouter.ts
@@ -53,7 +53,7 @@ router.get(
   '/',
   handlerWrapper(async (req, res) => {
     const query = { ...req.query };
-    query.ids = JSON.parse(req.query.ids);
+    query.ids = JSON.parse(req.query.ids || '[]');
     Joi.assert(
       query,
       Joi.object().keys({


### PR DESCRIPTION
## Context

https://github.com/Greenstand/treetracker-admin-client/issues/1038

I think the more scalable way is to update these sql queries so that we have a "base" that is shared anywhere. Though this task in on itself is out of scope and should ideally be a different effort. 

There's a lot of effort to "overhaul" things so unsure of the direction we are going and not sure if this repo is something we will continue with/ combined with something else?

## Manual Testing of the WebClient
1. `planters/[planter].js` Page
  - [x] show_in_map = False ||  the page goes into 404
  - [x] show_in_map = True || the page renders like normal

3. `trees/[treeid].js` Page
  - [x] associated show_in_map = False ||  the page goes into 404
  - [x] associated show_in_map = True || the page renders like normal
  
5. `top` Page
  - [x] featured trees -- remove the ones where planter.show_in_map= False
  - [x] featured trees -- show the ones where planter.show_in_map= True
  - [x] featured planters -- remove the ones where show_in_map= False
  - [x] featured planters -- show the ones where show_in_map= True


7. `organizations/[organizations].js` Page
  I'm a bit confused here but I guess we can hide the "trees" that are planted by planters that are supposed to be hidden(???)
  - [x] If planter is show_in_map=False, hide the tree
  - [x] If planter is show_in_map=True, show the tree
