### PR TITLE
fix: handle missing wallet lookup in WalletsRepository

### DIFF
--- a/server/infra/database/WalletsRepository.spec.ts
+++ b/server/infra/database/WalletsRepository.spec.ts
@@ -1,0 +1,67 @@
+import mockDb from 'mock-knex';
+import HttpError from 'utils/HttpError';
+import Session from './Session';
+import WalletsRepository from './WalletsRepository';
+
+jest.mock('./patch', () => ({
+  __esModule: true,
+  default: jest.fn((value) => Promise.resolve(value)),
+  PATCH_TYPE: {
+    EXTRA_WALLET: 'EXTRA_WALLET',
+  },
+}));
+
+describe('WalletsRepository', () => {
+  const session = new Session();
+  const repo = new WalletsRepository(session);
+  // eslint-disable-next-line
+  var tracker = require('mock-knex').getTracker();
+
+  beforeEach(() => {
+    mockDb.mock(session.getDB());
+    tracker.install();
+  });
+
+  afterEach(() => {
+    tracker.uninstall();
+    mockDb.unmock(session.getDB());
+  });
+
+  it('getWalletByIdOrName', async () => {
+    tracker.on('query', (query) => {
+      expect(query.sql).toMatch(/FROM\s+wallet\.wallet/i);
+      expect(query.sql).toMatch(/name = 'test-wallet-03'/);
+      query.response({
+        rows: [
+          {
+            id: '0faf4970-ac66-4bbc-a68a-c1e1881211fc',
+            name: 'test-wallet-03',
+            logo_url: null,
+            created_at: '2024-12-06T04:35:55.165Z',
+            about: null,
+          },
+        ],
+      });
+    });
+
+    const result = await repo.getWalletByIdOrName('test-wallet-03');
+    expect(result).toMatchObject({
+      id: '0faf4970-ac66-4bbc-a68a-c1e1881211fc',
+      name: 'test-wallet-03',
+    });
+  });
+
+  it('getWalletByIdOrName should throw 404 when wallet is missing', async () => {
+    tracker.on('query', (query) => {
+      expect(query.sql).toMatch(/FROM\s+wallet\.wallet/i);
+      expect(query.sql).toMatch(/name = 'dadiorchen'/);
+      query.response({
+        rows: [],
+      });
+    });
+
+    await expect(repo.getWalletByIdOrName('dadiorchen')).rejects.toMatchObject({
+      code: 404,
+    } as Partial<HttpError>);
+  });
+});

--- a/server/infra/database/WalletsRepository.ts
+++ b/server/infra/database/WalletsRepository.ts
@@ -29,10 +29,10 @@ export default class WalletsRepository extends BaseRepository<Wallets> {
 
     const object = await this.session.getDB().raw(sql);
 
-    if (!object && object.rows.length !== 1) {
+    if (!object?.rows || object.rows.length !== 1) {
       throw new HttpError(
         404,
-        `Can not found ${this.tableName} by id:${walletIdOrName} name:${walletIdOrName}`,
+        `Can not find ${this.tableName} by id:${walletIdOrName} name:${walletIdOrName}`,
       );
     }
     const objectPatched = await patch(


### PR DESCRIPTION
## Summary

This PR fixes wallet lookup failures in `WalletsRepository` and adds regression coverage for the missing-wallet case.

### Changes
- improve null/empty-result handling in `getWalletByIdOrName()`
- return a clean `404` when a wallet is not found instead of crashing on `undefined.id`
- add repository regression tests for:
  - successful wallet lookup by id/name
  - missing wallet lookup returning `404`

## Problem

Requests like `/wallets/dadiorchen` were returning `500` because the repository did not correctly handle an empty DB result before calling `patch()` on `object.rows[0]`.

Example failing response before this change:
{"code":500,"message":"Unknown error (Cannot read properties of undefined (reading 'id'))"}

## Result

Missing wallets now fail safely with `404`, and the regression test helps prevent this from coming back.

## Testing

Covered with repository tests for:
- existing wallet lookup
- missing wallet lookup