### PR TITLE
ci: bump dev release job Node to 22.14.0 for semantic-release v25

### DIFF
--- a/.github/workflows/treetracker-query-api-build-deploy-dev.yml
+++ b/.github/workflows/treetracker-query-api-build-deploy-dev.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: ${{ github.event.inputs.git-tag }}
-      - name: Use Node.js 20.8.1 #semantic-release
-        uses: actions/setup-node@v1
+      - name: Use Node.js 22.14.0
+        uses: actions/setup-node@v4
         with:
-          node-version: '20.8.1'
+          node-version: '22.14.0'
 
       - name: npm clean install
         run: npm ci


### PR DESCRIPTION
The "Release and Deploy to Dev" workflow installs the latest
semantic-release globally, which as of v25 requires
Node ^22.14.0 || >=24.10.0. The job pinned Node 20.8.1, so the
Release step failed with:
node version ^22.14.0 || >= 24.10.0 is required. Found v20.8.1.
Bump the release job to Node 22.14.0 and actions/setup-node v1 -> v4