### PR TITLE
ci: pin kustomize install in dev deploy job

### DIFF
--- a/.github/workflows/treetracker-query-api-build-deploy-dev.yml
+++ b/.github/workflows/treetracker-query-api-build-deploy-dev.yml
@@ -85,9 +85,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install kustomize
-        run: curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+        run: |
+          KUSTOMIZE_VERSION=5.8.1
+          curl -fsSL -o /tmp/kustomize.tar.gz \
+            "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${KUSTOMIZE_VERSION}/kustomize_v${KUSTOMIZE_VERSION}_linux_amd64.tar.gz"
+          tar -xzf /tmp/kustomize.tar.gz -C /tmp
+          sudo install -m 0755 /tmp/kustomize /usr/local/bin/kustomize
+          kustomize version
       - name: Run kustomize
-        run: (cd deployment/base && ../../kustomize edit set image greenstand/${{ github.event.repository.name }}:${{ needs.release.outputs.bumped_version }} )
+        run: (cd deployment/base && kustomize edit set image greenstand/${{ github.event.repository.name }}:${{ needs.release.outputs.bumped_version }} )
       - name: Install doctl for kubernetes
         uses: digitalocean/action-doctl@v2
         with:


### PR DESCRIPTION
The deploy job installed kustomize via the upstream install_kustomize.sh helper, which resolves the latest release through the GitHub API. From CI runners that unauthenticated call gets rate-limited and returns no tarball, so the download glob matched nothing and tar failed:
tar: ./kustomize_v*_linux_amd64.tar.gz: Cannot open: No such file or directory
Replace it with a pinned, direct download of kustomize v5.8.1 from the official release URL into /usr/local/bin (deterministic, no API call,fails fast with curl -f). Switch the "Run kustomize" step from the relative ../../kustomize path to the PATH binary so both kustomize steps use the same install.